### PR TITLE
Feat 4 lokilogimpl

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "configurations": [
+        {
+            "type": "java",
+            "name": "Spring Boot-Application<service-controller>",
+            "request": "launch",
+            "cwd": "${workspaceFolder}",
+            "console": "internalConsole",
+            "mainClass": "net.boomerangplatform.Application",
+            "projectName": "service-controller",
+            "args": ""
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.exclude": {
+        "**/.classpath": true,
+        "**/.project": true,
+        "**/.settings": true,
+        "**/.factorypath": true
+    }
+}


### PR DESCRIPTION
Closes #

Grafana Loki Service controller iteration 1 integrated into bmrg controller  

#### Changelog

**New**

- new method streamLogsFromLoki added

**Changed**

- StreamLogsForTask calls streamLogsFromLoki

**Removed**

- N/A

#### Testing / Reviewing

Please build and run this new feature and provide feedback. This addition can be a good starting point for a full integration with Grafana Loki. 


**Prerequisites (Promtail config):**
```
scrapeConfigs: 

# pipeline handling flow setup
- job_name: bmrg-k8s-job-flow
  pipeline_stages:
    - docker: {}
  kubernetes_sd_configs:
    - role: pod
  relabel_configs:
  # bmrg specific labels
    - source_labels:
      - __meta_kubernetes_pod_label_activity_id
      target_label: bmrg_activity
    - source_labels:
      - __meta_kubernetes_pod_label_task_id
      target_label: bmrg_task
    - source_labels:
      - __meta_kubernetes_pod_label_workflow_id
      target_label: bmrg_workflow
    - source_labels:
      - __meta_kubernetes_pod_node_name
      target_label: __host__
    - source_labels:
      - __meta_kubernetes_pod_label_product
      target_label: __bmrg_product__
    - source_labels:
      - __meta_kubernetes_pod_label_tier
      target_label: __bmrg_tier__
    - source_labels:
      - __meta_kubernetes_pod_label_platform
      target_label: __bmrg_platform__

# delete those logs which cannot be associated with an activity id, task id and workflow id 
    - action: drop
      regex: ''
      source_labels:
      - bmrg_activity
    - action: drop
      regex: ''
      source_labels:
      - bmrg_workflow
    - action: drop
      regex: ''
      source_labels:
      - bmrg_task

# aggregated log stream <namespace>/<activityID>/<workflowID>/<taskID> under bmrg_activity_per_namespace
    - action: replace
      replacement: $1
      separator: /
      source_labels:
      - __meta_kubernetes_namespace
      - bmrg_activity
      - bmrg_workflow
      - bmrg_task
      target_label: bmrg_activity_per_namespace

# aggregated log stream <bmrg_product eg: flow, cicd>/<activityID>/<workflowID>/<taskID> under bmrg_activity_per_product
    - action: replace
      replacement: $1
      separator: /
      source_labels:
      - __bmrg_product__
      - bmrg_activity
      - bmrg_workflow
      - bmrg_task
      target_label: bmrg_activity_per_product

# aggregate log stream corresponding to a docker logfile path (example taken from the default config)
    - replacement: /var/log/pods/*$1/*.log
      separator: /
      source_labels:
      - __meta_kubernetes_pod_uid
      - __meta_kubernetes_pod_container_name
      target_label: __path__

  
# pipeline handling cicd setup
- job_name: bmrg-k8s-job-cicd
  pipeline_stages:
    - docker: {}
  kubernetes_sd_configs:
    - role: pod
  relabel_configs:
  # bmrg specific labels
    - source_labels:
      - __meta_kubernetes_pod_label_activity_id
      target_label: bmrg_activity
    - source_labels:
      - __meta_kubernetes_pod_label_task_id
      target_label: bmrg_task
    - source_labels:
      - __meta_kubernetes_pod_label_component_id
      target_label: bmrg_workflow
    - source_labels:
      - __meta_kubernetes_pod_node_name
      target_label: __host__
    - source_labels:
      - __meta_kubernetes_pod_label_product
      target_label: __bmrg_product__
    - source_labels:
      - __meta_kubernetes_pod_label_tier
      target_label: __bmrg_tier__
    - source_labels:
      - __meta_kubernetes_pod_label_platform
      target_label: __bmrg_platform__

# delete those logs which cannot be associated with an activity id, task id and workflow id 
    - action: drop
      regex: ''
      source_labels:
      - bmrg_activity
    - action: drop
      regex: ''
      source_labels:
      - bmrg_workflow
    - action: drop
      regex: ''
      source_labels:
      - bmrg_task

# aggregated log stream <namespace>/<activityID>/<workflowID>/<taskID> under bmrg_activity_per_namespace
    - action: replace
      replacement: $1
      separator: /
      source_labels:
      - __meta_kubernetes_namespace
      - bmrg_activity
      - bmrg_workflow
      - bmrg_task
      target_label: bmrg_activity_per_namespace

# aggregated log stream <bmrg_product eg: flow, cicd>/<activityID>/<workflowID>/<taskID> under bmrg_activity_per_product
    - action: replace
      replacement: $1
      separator: /
      source_labels:
      - __bmrg_product__
      - bmrg_activity
      - bmrg_workflow
      - bmrg_task
      target_label: bmrg_activity_per_product

# aggregate log stream corresponding to a docker logfile path (example taken from the default config)
    - replacement: /var/log/pods/*$1/*.log
      separator: /
      source_labels:
      - __meta_kubernetes_pod_uid
      - __meta_kubernetes_pod_container_name
      target_label: __path__
```
