### PR TITLE
Feat 76 lifecycle task config

### DIFF
--- a/src/main/java/net/boomerangplatform/model/TaskConfiguration.java
+++ b/src/main/java/net/boomerangplatform/model/TaskConfiguration.java
@@ -8,21 +8,32 @@ public class TaskConfiguration {
 
   private Boolean debug;
 
+  private Boolean lifecycle;
+
   private TaskDeletionEnum deletion;
 
-	public Boolean getDebug() {
-		return debug ;
-	}
+  public Boolean getDebug() {
+    return debug;
+  }
 
-	public void setDebug(Boolean debug) {
-		this.debug = debug;
-	}
+  public void setDebug(Boolean debug) {
+    this.debug = debug;
+  }
 
-	public TaskDeletionEnum getDeletion() {
-		return deletion ;
-	}
+  public Boolean getLifecycle() {
+    return lifecycle;
+  }
 
-	public void setDeletion(TaskDeletionEnum deletion) {
-		this.deletion = deletion;
-	}
+  public void setLifecycle(Boolean lifecycle) {
+    this.lifecycle = lifecycle;
+  }
+
+  public TaskDeletionEnum getDeletion() {
+    return deletion;
+  }
+
+  public void setDeletion(TaskDeletionEnum deletion) {
+    this.deletion = deletion;
+  }
+
 }

--- a/src/main/java/net/boomerangplatform/service/TaskServiceImpl.java
+++ b/src/main/java/net/boomerangplatform/service/TaskServiceImpl.java
@@ -70,7 +70,7 @@ public class TaskServiceImpl implements TaskService {
                   kubeService.createTaskConfigMap(task.getWorkflowName(), task.getWorkflowId(),
                           task.getTaskActivityId(), task.getTaskName(), task.getTaskId(), task.getParameters());
                   kubeService.watchConfigMap(null, task.getTaskActivityId(), task.getTaskId());
-                  boolean createWatchLifecycle = task.getArguments().contains("shell") ? Boolean.TRUE : Boolean.FALSE;
+                  boolean createWatchLifecycle = task.getConfiguration().getLifecycle() ? Boolean.TRUE : Boolean.FALSE;
                   String workspaceId = task.getWorkspaces() != null && task.getWorkspaces().get(0) != null ? task.getWorkspaces().get(0).getWorkspaceId() : null;
                   kubeService.createJob(createWatchLifecycle, workspaceId, task.getWorkflowName(), task.getWorkflowId(),
                           task.getWorkflowActivityId(), task.getTaskActivityId(), task.getTaskName(), task.getTaskId(),


### PR DESCRIPTION
Closes #boomerang-io/roadmap#76

Implements an option for enabling the Lifecycle worker for any Task rather than being hard coded to the Shell task to enable increased adoption by community tasks

#### Changelog

**New**

- enableLifecycle Boolean in the Task model

**Changed**

- enableLifecycle is now referenced instead of the task name to determine when to add the lifecycle init and sidecar container

**Removed**

- {{removed thing}}

